### PR TITLE
Muda os objetivos de assassinate para assassinate once [cit]

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -184,6 +184,29 @@ GLOBAL_LIST_EMPTY(objectives)
 /datum/objective/assassinate/admin_edit(mob/admin)
 	admin_simple_target_pick(admin)
 
+/datum/objective/assassinate/once
+	name = "kill once"
+	var/won = FALSE
+
+/datum/objective/assassinate/once/update_explanation_text()
+	..()
+	if(target && target.current)
+		explanation_text = "Kill [target.name], the [!target_role_type ? target.assigned_role : target.special_role]. ATTENTION: You only need to kill them once; if they come back, you've still succeeded."
+		START_PROCESSING(SSprocessing,src)
+	else
+		explanation_text = "Free Objective"
+
+/datum/objective/assassinate/once/check_completion()
+	return won || ..()
+
+/datum/objective/assassinate/once/process()
+	won = tick_check_completion()
+	if(won)
+		STOP_PROCESSING(SSprocessing,src)
+
+/datum/objective/assassinate/once/proc/tick_check_completion()
+	return won || !considered_alive(target) //The target afking / logging off for a bit during the round doesn't complete it, but them being afk at roundend does.
+
 /datum/objective/assassinate/internal
 	var/stolen = FALSE //Have we already eliminated this target?
 

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -448,7 +448,7 @@
 		objectives += destroy_objective
 	else
 		if(prob(70))
-			var/datum/objective/assassinate/kill_objective = new
+			var/datum/objective/assassinate/once/kill_objective = new
 			kill_objective.owner = owner
 			kill_objective.find_target()
 			objectives += kill_objective

--- a/code/modules/antagonists/malf_ai/datum_malf_ai.dm
+++ b/code/modules/antagonists/malf_ai/datum_malf_ai.dm
@@ -55,7 +55,7 @@
 	// for(in...to) loops iterate inclusively, so to reach objective_limit we need to loop to objective_limit - 1
 	// This does not give them 1 fewer objectives than intended.
 	for(var/i in objective_count to objective_limit - 1)
-		var/datum/objective/assassinate/kill_objective = new
+		var/datum/objective/assassinate/once/kill_objective = new
 		kill_objective.owner = owner
 		kill_objective.find_target()
 		objectives += kill_objective

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -145,7 +145,7 @@
 			maroon_objective.find_target()
 			return maroon_objective
 
-		var/datum/objective/assassinate/kill_objective = new
+		var/datum/objective/assassinate/once/kill_objective = new
 		kill_objective.owner = owner
 		kill_objective.find_target()
 		return kill_objective


### PR DESCRIPTION
Altera todos os objetivos de assassinate para assassinate/once, onde você só precisa matar seu alvo uma única vez, mesmo se ele for revivido.

Da última vez, ele floodava runtime. 

"Insanity is doing the same thing over and over again but expecting different results"