### PR TITLE
[NON-MODULAR] Conserta o objetivo de roubar o Hypospray

### DIFF
--- a/code/game/gamemodes/objective_items.dm
+++ b/code/game/gamemodes/objective_items.dm
@@ -63,7 +63,7 @@
 
 /datum/objective_item/steal/hypo
 	name = "the hypospray."
-	targetitem = /obj/item/reagent_containers/hypospray/cmo
+	targetitem = /obj/item/hypospray/mkii/CMO //Nebula change - TG doesn't have these and SR has ambitions, had to update it
 	difficulty = 5
 	excludefromjob = list("Chief Medical Officer")
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Por conta que o TG não tem esses Hyposprays novos e o Skyrat usa o sistema de ambitions, o code deste objetivo não foi atualizado e ainda requer um item que não se encontra mais na posse do CMO, este tendo sido substituído por um modelo mais novo, este PR só atualiza o objetivo.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Eu realmente tenho que ficar escrevendo nessa seção? Enfim, permite os traidores a fazerem greentext.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog
Conserta o objetivo de traidor de roubar o Hypospray.
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: Objetivo de roubar Hypospray agora requer o Hypospray novo.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
