### PR TITLE
Remove safety obrigatória das armas (elas ainda tem, só que o jogo não liga se estão ligadas.)

### DIFF
--- a/modular_skyrat/modules/gunsafety/code/gun_safety.dm
+++ b/modular_skyrat/modules/gunsafety/code/gun_safety.dm
@@ -1,11 +1,11 @@
 /obj/item/gun/ballistic
-	has_gun_safety = TRUE
+	has_gun_safety = FALSE
 
 /obj/item/gun/ballistic/bow
 	has_gun_safety = FALSE
 
 /obj/item/gun/energy
-	has_gun_safety = TRUE
+	has_gun_safety = FALSE
 
 /obj/item/gun/energy/kinetic_accelerator/minebot
 	has_gun_safety = FALSE


### PR DESCRIPTION
## Sobre o pull request

Esse PR não salva nada disso mas está além de meu controle salvar um code sem salvação, esse PR só tira safety das armas, o botão continua lá, só não é obrigado apertar ele, o jogo ignora o que está no botão.

Agora, permita-me contar o QUANTO eu ODEIO esse code. _**(Não é importante pro PR, pode ignorar.)**_


-mudanças sem consideração do balancing geral

-buffs desnecessários em prol do "RP" quando eles removem itens que fariam bom RP, como os bioterror nanites

-codebase high-roleplay com mais tática de powergaming do que beestation

-nanotrasen ter laser e sindicato ter balística era uma tática escondida pra evitar friendly fire, já que as armaduras aguentam coisas diferentes, se todo mundo tá usando a mesma merda, tu já sabe onde isso vai

-indo no assunto de arma o sindicato tem defesa contra qualquer arma que a NT tem na estação, já que é tudo balístico

-a diferença dos coders ficarem trocando toda semana por eles tratarem os coders mal é notável no código com mudanças bruscas de escrita, descrições, métodos e práticas de programação
-adicionar features que não adicionam muito ao jogo apenas "por ser legal" como a frota e o overmap é exatamente o que precisamos com balancing tão bosta, não é?

-opt-in forçado ao sistema de ambitions, mesmo que eles tinham feito esse sistema direito no skyrat antigo fazendo ele ser opcional, porque raios eles regrediriam nisso porra, eles já tinham O CÓDIGO PRONTO!

-codebase high-roleplay sem lore porque priorizaram criar itens de sexo mais do que o hyperstation, se a porra do hyperstation tem qualquer coisa reminiscente de lore mas o seu code não, essa é uma bandeira vermelha ENORME

## Changelog
:cl:
del: Removido safety obrigatória.
/:cl: